### PR TITLE
Remove autoload re-dump optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ var_dump($version); // 1.0.0@0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33
 composer require ocramius/package-versions
 ```
 
+It is suggested that you re-dump the autoloader in order to prevent
+autoload I/O when accessing the `PackageVersions\Versions` API:
+
+```sh
+composer dump-autoload --optimize
+```
+
 ### Use-cases
 
 This repository implements `PackageVersions\Versions::getVersion()` in such a way that no IO

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -92,8 +92,6 @@ PHP;
             $composer->getPackage()
         );
 
-        self::reDumpAutoloader($composer);
-
         $io->write('<info>ocramius/package-versions:</info> ...done generating version class');
     }
 
@@ -155,23 +153,6 @@ PHP;
         }
 
         return $package;
-    }
-
-    /**
-     * @param Composer $composer
-     *
-     * @return void
-     */
-    private static function reDumpAutoloader(Composer $composer)
-    {
-        $composer->getAutoloadGenerator()->dump(
-            $composer->getConfig(),
-            $composer->getRepositoryManager()->getLocalRepository(),
-            $composer->getPackage(),
-            $composer->getInstallationManager(),
-            'composer',
-            true // CBA to provide this manually, for now
-        );
     }
 
     /**

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -86,7 +86,6 @@ final class InstallerTest extends PHPUnit_Framework_TestCase
     {
         $config            = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $locker            = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
-        $autoloadGenerator = $this->getMockBuilder(AutoloadGenerator::class)->disableOriginalConstructor()->getMock();
         $repositoryManager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
         $installManager    = $this->getMockBuilder(InstallationManager::class)->disableOriginalConstructor()->getMock();
         $repository        = $this->getMock(InstalledRepositoryInterface::class);
@@ -129,12 +128,10 @@ final class InstallerTest extends PHPUnit_Framework_TestCase
                 ],
             ]);
 
-        $autoloadGenerator->expects(self::once())->method('dump');
         $repositoryManager->expects(self::any())->method('getLocalRepository')->willReturn($repository);
 
         $this->composer->expects(self::any())->method('getConfig')->willReturn($config);
         $this->composer->expects(self::any())->method('getLocker')->willReturn($locker);
-        $this->composer->expects(self::any())->method('getAutoloadGenerator')->willReturn($autoloadGenerator);
         $this->composer->expects(self::any())->method('getRepositoryManager')->willReturn($repositoryManager);
         $this->composer->expects(self::any())->method('getPackage')->willReturn($package);
         $this->composer->expects(self::any())->method('getInstallationManager')->willReturn($installManager);
@@ -201,7 +198,6 @@ PHP;
     {
         $config            = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $locker            = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
-        $autoloadGenerator = $this->getMockBuilder(AutoloadGenerator::class)->disableOriginalConstructor()->getMock();
         $repositoryManager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
         $installManager    = $this->getMockBuilder(InstallationManager::class)->disableOriginalConstructor()->getMock();
         $repository        = $this->getMock(InstalledRepositoryInterface::class);
@@ -235,12 +231,10 @@ PHP;
                 ],
             ]);
 
-        $autoloadGenerator->expects(self::once())->method('dump');
         $repositoryManager->expects(self::any())->method('getLocalRepository')->willReturn($repository);
 
         $this->composer->expects(self::any())->method('getConfig')->willReturn($config);
         $this->composer->expects(self::any())->method('getLocker')->willReturn($locker);
-        $this->composer->expects(self::any())->method('getAutoloadGenerator')->willReturn($autoloadGenerator);
         $this->composer->expects(self::any())->method('getRepositoryManager')->willReturn($repositoryManager);
         $this->composer->expects(self::any())->method('getPackage')->willReturn($package);
         $this->composer->expects(self::any())->method('getInstallationManager')->willReturn($installManager);
@@ -309,7 +303,6 @@ PHP;
     {
         $config            = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $locker            = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
-        $autoloadGenerator = $this->getMockBuilder(AutoloadGenerator::class)->disableOriginalConstructor()->getMock();
         $repositoryManager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
         $installManager    = $this->getMockBuilder(InstallationManager::class)->disableOriginalConstructor()->getMock();
         $repository        = $this->getMock(InstalledRepositoryInterface::class);
@@ -340,12 +333,10 @@ PHP;
                 ],
             ]);
 
-        $autoloadGenerator->expects(self::once())->method('dump');
         $repositoryManager->expects(self::any())->method('getLocalRepository')->willReturn($repository);
 
         $this->composer->expects(self::any())->method('getConfig')->willReturn($config);
         $this->composer->expects(self::any())->method('getLocker')->willReturn($locker);
-        $this->composer->expects(self::any())->method('getAutoloadGenerator')->willReturn($autoloadGenerator);
         $this->composer->expects(self::any())->method('getRepositoryManager')->willReturn($repositoryManager);
         $this->composer->expects(self::any())->method('getPackage')->willReturn($package);
         $this->composer->expects(self::any())->method('getInstallationManager')->willReturn($installManager);
@@ -417,7 +408,6 @@ PHP;
     {
         $config            = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $locker            = $this->getMockBuilder(Locker::class)->disableOriginalConstructor()->getMock();
-        $autoloadGenerator = $this->getMockBuilder(AutoloadGenerator::class)->disableOriginalConstructor()->getMock();
         $repositoryManager = $this->getMockBuilder(RepositoryManager::class)->disableOriginalConstructor()->getMock();
         $installManager    = $this->getMockBuilder(InstallationManager::class)->disableOriginalConstructor()->getMock();
         $repository        = $this->getMock(InstalledRepositoryInterface::class);
@@ -440,12 +430,10 @@ PHP;
                 'packages-dev' => [],
             ]);
 
-        $autoloadGenerator->expects(self::once())->method('dump');
         $repositoryManager->expects(self::any())->method('getLocalRepository')->willReturn($repository);
 
         $this->composer->expects(self::any())->method('getConfig')->willReturn($config);
         $this->composer->expects(self::any())->method('getLocker')->willReturn($locker);
-        $this->composer->expects(self::any())->method('getAutoloadGenerator')->willReturn($autoloadGenerator);
         $this->composer->expects(self::any())->method('getRepositoryManager')->willReturn($repositoryManager);
         $this->composer->expects(self::any())->method('getPackage')->willReturn($rootPackage);
         $this->composer->expects(self::any())->method('getInstallationManager')->willReturn($installManager);


### PR DESCRIPTION
Users should just re-dump the autoloader via `composer dump-autoload --optimize` manually (post-install)

This logic caused other plugins to conflict (see https://github.com/puli/issues/issues/183#issuecomment-189282691 )