### PR TITLE
Workaround for composer/composer#5237 - class parsing

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -27,7 +27,7 @@ namespace PackageVersions;
  *
  * This file is overwritten at every run of `composer install` or `composer update`.
  */
-final class Versions
+%s
 {
     const VERSIONS = %s;
 
@@ -99,6 +99,7 @@ PHP;
     {
         return sprintf(
             self::$generatedClassTemplate,
+            'fin' . 'al ' . 'cla' . 'ss ' . 'Versions', // note: workaround for regex-based code parsers :-(
             var_export(iterator_to_array(self::getVersions($composer->getLocker(), $composer->getPackage())), true)
         );
     }

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -524,4 +524,18 @@ PHP;
             )
         );
     }
+
+    /**
+     * @group composer/composer#5237
+     */
+    public function testWillEscapeRegexParsingOfClassDefinitions()
+    {
+        self::assertSame(
+            1,
+            preg_match_all(
+                '{^((?:final\s+)?(?:\s*))class\s+(\S+)}mi',
+                file_get_contents((new \ReflectionClass(Installer::class))->getFileName())
+            )
+        );
+    }
 }

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -44,6 +44,8 @@ final class InstallerTest extends PHPUnit_Framework_TestCase
 
     /**
      * {@inheritDoc}
+     * 
+     * @throws \PHPUnit_Framework_Exception
      */
     protected function setUp()
     {
@@ -297,6 +299,8 @@ PHP;
 
     /**
      * @group #12
+     * 
+     * @throws \RuntimeException
      */
     public function testDumpVersionsWithoutPackageSourceDetails()
     {
@@ -402,6 +406,8 @@ PHP;
      *
      * @param RootPackageInterface $rootPackage
      * @param bool                 $inVendor
+     *
+     * @throws \RuntimeException
      */
     public function testDumpsVersionsClassToSpecificLocation(RootPackageInterface $rootPackage, bool $inVendor)
     {

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -2,7 +2,6 @@
 
 namespace PackageVersionsTest;
 
-use Composer\Autoload\AutoloadGenerator;
 use Composer\Composer;
 use Composer\Config;
 use Composer\EventDispatcher\EventDispatcher;

--- a/test/PackageVersionsTest/VersionsTest.php
+++ b/test/PackageVersionsTest/VersionsTest.php
@@ -28,7 +28,7 @@ final class VersionsTest extends PHPUnit_Framework_TestCase
 
     public function testInvalidVersionsAreRejected()
     {
-        $this->setExpectedException(\OutOfBoundsException::class);
+        $this->expectException(\OutOfBoundsException::class);
 
         Versions::getVersion(uniqid('', true) . '/' . uniqid('', true));
     }


### PR DESCRIPTION
Temporary workaround for composer/composer#5237 - avoids regex parsing of a class template