### PR TITLE
Require phpunit/phpunit with tilde

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer-plugin-api": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit":   "^5.2.8",
+        "phpunit/phpunit":   "~5.2.8",
         "composer/composer": "^1.0.0-ALPHA11@ALPHA"
     },
     "autoload": {


### PR DESCRIPTION
Current version constraint allowed PHPUnit 5.3+ which in turn has already deprecated the `getMock`, so local test runs would be broken.