### PR TITLE
Add versions composer command

### DIFF
--- a/src/PackageVersions/CommandProvider.php
+++ b/src/PackageVersions/CommandProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PackageVersions;
+
+use Composer\Plugin\Capability\CommandProvider as CommandProviderInterface;
+use Composer\Plugin\Capability\Composer;
+
+/**
+ * Class CommandProvider
+ */
+class CommandProvider implements CommandProviderInterface
+{
+    public function getCommands()
+    {
+        return [
+            new VersionsCommand()
+        ];
+    }
+}

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -10,11 +10,13 @@ use Composer\Package\AliasPackage;
 use Composer\Package\Locker;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
+use Composer\Plugin\Capability\CommandProvider as CommandProviderInterface;
+use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 
-final class Installer implements PluginInterface, EventSubscriberInterface
+final class Installer implements PluginInterface, EventSubscriberInterface, Capable
 {
     private static $generatedClassTemplate = <<<'PHP'
 <?php
@@ -175,5 +177,15 @@ PHP;
         }
 
         yield $rootPackage->getName() => $rootPackage->getVersion() . '@' . $rootPackage->getSourceReference();
+    }
+
+    /**
+     * @return array
+     */
+    public function getCapabilities() : array
+    {
+        return [
+            CommandProviderInterface::class => CommandProvider::class,
+        ];
     }
 }

--- a/src/PackageVersions/VersionsCommand.php
+++ b/src/PackageVersions/VersionsCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PackageVersions;
+
+use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class CommandProvider
+ */
+class VersionsCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('versions')
+            ->addArgument('package', InputArgument::OPTIONAL, 'Package name to display version for')
+        ;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return integer
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        if ($packageName = $input->getArgument('package')) {
+            $output->writeln('Installed version:');
+            $this->dumpPackageVersion($output, $packageName, Versions::getVersion($packageName));
+
+            return 0;
+        }
+
+        $output->writeln('Installed versions:');
+        $versionsSorted = \PackageVersions\Versions::VERSIONS;
+        ksort($versionsSorted);
+
+        foreach ($versionsSorted as $packageName => $version) {
+            $this->dumpPackageVersion($output, $packageName, $version);
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @param string $packageName
+     * @param string $version
+     */
+    private function dumpPackageVersion(OutputInterface $output, string $packageName, string $version)
+    {
+        list($version, $hash) = explode('@', $version);
+
+        $output->writeln(sprintf(
+            '<info>%s</info>: %s@%s',
+            $packageName,
+            $version,
+            $hash
+        ));
+    }
+}

--- a/test/PackageVersionsTest/CommandProviderTest.php
+++ b/test/PackageVersionsTest/CommandProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PackageVersionsTest;
+
+use PackageVersions\CommandProvider;
+use PackageVersions\VersionsCommand;
+
+/**
+ * Class CommandProviderTest
+ */
+class CommandProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetCommands()
+    {
+        $commands = (new CommandProvider())->getCommands();
+
+        static::assertCount(1, $commands);
+        static::assertInstanceOf(VersionsCommand::class, $commands[0]);
+    }
+}

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -14,6 +14,7 @@ use Composer\Package\RootPackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\RepositoryManager;
 use Composer\Script\Event;
+use PackageVersions\CommandProvider;
 use PackageVersions\Installer;
 use PHPUnit_Framework_TestCase;
 
@@ -542,5 +543,12 @@ PHP;
                 file_get_contents((new \ReflectionClass(Installer::class))->getFileName())
             )
         );
+    }
+
+    public function testHasCommandProviderCapability()
+    {
+        $installer = new Installer();
+
+        static::assertContains(CommandProvider::class, $installer->getCapabilities());
     }
 }

--- a/test/PackageVersionsTest/VersionsCommandTest.php
+++ b/test/PackageVersionsTest/VersionsCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace PackageVersionsTest;
+
+use PackageVersions\Versions;
+use PackageVersions\VersionsCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class VersionsCommandTest
+ */
+class VersionsCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfigure()
+    {
+        $command = new VersionsCommand();
+        static::assertEquals('versions', $command->getName());
+    }
+
+    public function testExecute()
+    {
+        $application = new Application();
+        $application->add(new VersionsCommand());
+
+        $command = $application->find('versions');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+        $display = $commandTester->getDisplay();
+
+        foreach (Versions::VERSIONS as $packageName => $version) {
+            list($version, ) = explode('@', $version);
+            static::assertContains($packageName.': '.$version, $display);
+        }
+    }
+
+    public function testExecuteWithPackage()
+    {
+        $application = new Application();
+        $application->add(new VersionsCommand());
+
+        $command = $application->find('versions');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), 'package' => 'ocramius/package-versions'));
+
+        list($version, ) = explode('@', Versions::VERSIONS['ocramius/package-versions']);
+
+        static::assertContains('ocramius/package-versions', $commandTester->getDisplay());
+        static::assertContains($version, $commandTester->getDisplay());
+    }
+}


### PR DESCRIPTION
This adds a command that either lists all the installed versions, or shows a chosen package's version. Hopefully @seldaek has no plans for this one.
Possible next step: add some ANSI highlights to versions, so that the version is displayed in <bold> as opposed to SHA that should be displayed in gray.
Maybe it's worth also adding an option that would hide the SHAs.