### PR TITLE
Fix incompatibility with --classmap-authoritative

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -5,5 +5,5 @@ if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ] ; then
     hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar update --prefer-source
 else
     composer self-update
-    composer update --prefer-source --classmap-authoritative $DEPENDENCIES
+    composer update --prefer-source $DEPENDENCIES
 fi

--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -5,5 +5,5 @@ if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ] ; then
     hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar update --prefer-source
 else
     composer self-update
-    composer update --prefer-source $DEPENDENCIES
+    composer update --prefer-source --classmap-authoritative $DEPENDENCIES
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 env:
   - DEPENDENCIES=""
   - DEPENDENCIES="--prefer-lowest --prefer-stable"
+  - DEPENDENCIES="--classmap-authoritative"
 
 before_script:
   - sh .travis.install.sh

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     "autoload": {
         "psr-4": {
             "PackageVersions\\": "src/PackageVersions"
-        }
+        },
+        "files": [
+            "src/PackageVersions/Versions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
I tried to replace `--optimize-autoloader` with `--classmap-authoritative` for my CI and got this exception:

```
  Fatal error: Class 'PackageVersions\Versions' not found 
```

It seems that the Versions class was generated but is missing in the composer autoloading classmap because when I added the file manually in composer.json it works fine:

```
    "autoload": {
        //...
        "files": [
            "vendor/ocramius/package-versions/src/PackageVersions/Versions.php"
        ]
    },
```