### PR TITLE
Ignore the global plugin when updating local projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpunit/phpunit":   "^5.4.7",
-        "composer/composer": "^1.2.2",
+        "composer/composer": "^1.3",
         "ext-zip":           "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "phpunit/phpunit":   "^5.4.7",
-        "composer/composer": "^1.2.0"
+        "composer/composer": "^1.2.0",
+        "ext-zip": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,8 @@
     },
     "require-dev": {
         "phpunit/phpunit":   "^5.4.7",
-        "composer/composer": "^1.2.0",
-        "ext-zip":           "*",
-        "symfony/process":   "^2.3"
+        "composer/composer": "^1.2.2",
+        "ext-zip":           "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require-dev": {
         "phpunit/phpunit":   "^5.4.7",
         "composer/composer": "^1.2.0",
-        "ext-zip": "*"
+        "ext-zip":           "*",
+        "symfony/process":   "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -80,14 +80,20 @@ PHP;
      */
     public static function dumpVersionsClass(Event $composerEvent)
     {
-        $io = $composerEvent->getIO();
+        $composer = $composerEvent->getComposer();
+        $versions = iterator_to_array(self::getVersions($composer->getLocker(), $composer->getPackage()));
 
+        if (!isset($versions['ocramius/package-versions'])) {
+            //plugin must be globally installed - we only want to generate versions for projects which specifically
+            //require ocramius/package-versions
+            return;
+        }
+
+        $io = $composerEvent->getIO();
         $io->write('<info>ocramius/package-versions:</info>  Generating version class...');
 
-        $composer = $composerEvent->getComposer();
-
         self::writeVersionClassToFile(
-            self::generateVersionsClass($composer),
+            self::generateVersionsClass($versions),
             $composer->getConfig(),
             $composer->getPackage()
         );
@@ -95,12 +101,12 @@ PHP;
         $io->write('<info>ocramius/package-versions:</info> ...done generating version class');
     }
 
-    private static function generateVersionsClass(Composer $composer) : string
+    private static function generateVersionsClass(array $versions) : string
     {
         return sprintf(
             self::$generatedClassTemplate,
             'fin' . 'al ' . 'cla' . 'ss ' . 'Versions', // note: workaround for regex-based code parsers :-(
-            var_export(iterator_to_array(self::getVersions($composer->getLocker(), $composer->getPackage())), true)
+            var_export($versions, true)
         );
     }
 

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -83,7 +83,7 @@ PHP;
         $composer = $composerEvent->getComposer();
         $versions = iterator_to_array(self::getVersions($composer->getLocker(), $composer->getPackage()));
 
-        if (!isset($versions['ocramius/package-versions'])) {
+        if (!array_key_exists('ocramius/package-versions', $versions)) {
             //plugin must be globally installed - we only want to generate versions for projects which specifically
             //require ocramius/package-versions
             return;

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -140,17 +140,8 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
             iterator_to_array(new RecursiveIteratorIterator(
                 new RecursiveCallbackFilterIterator(
                     new RecursiveDirectoryIterator(realpath(__DIR__ . '/../../'), RecursiveDirectoryIterator::SKIP_DOTS),
-                    function (SplFileInfo $file) {
-                        $filePath = substr($file->getRealPath(), strlen(realpath(__DIR__ . '/../../')) + 1);
-
-                        if (substr($filePath, 0, 4) === '.git'
-                            || substr($filePath, 0, 5) === '.idea'
-                            || substr($filePath, 0, 6) === 'vendor'
-                        ) {
-                            return false;
-                        }
-
-                        return true;
+                    function (SplFileInfo $file, $key, RecursiveDirectoryIterator $iterator) {
+                        return $iterator->getSubPathname()[0]  !== '.' && $iterator->getSubPathname() !== 'vendor';
                     }
                 ),
                 RecursiveIteratorIterator::LEAVES_ONLY

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace PackageVersionsTest;
+
+use PHPUnit_Framework_TestCase;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use ZipArchive;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class E2EInstaller extends PHPUnit_Framework_TestCase
+{
+    private $tempGlobalComposerHome;
+    private $tempLocalComposerHome;
+    private $tempArtifact;
+
+    public function setUp()
+    {
+        $this->tempGlobalComposerHome = sys_get_temp_dir() . '/' . uniqid('InstallerTest', true) . '/global';
+        $this->tempLocalComposerHome = sys_get_temp_dir() . '/' . uniqid('InstallerTest', true) . '/local';
+        $this->tempArtifact = sys_get_temp_dir() . '/' . uniqid('InstallerTest', true) . '/artifacts';
+        mkdir($this->tempGlobalComposerHome, 0777, true);
+        mkdir($this->tempLocalComposerHome, 0777, true);
+        mkdir($this->tempArtifact, 0777, true);
+
+        putenv('COMPOSER_HOME=' . $this->tempGlobalComposerHome);
+    }
+
+    public function tearDown()
+    {
+        $this->rmDir($this->tempGlobalComposerHome);
+        $this->rmDir($this->tempLocalComposerHome);
+        $this->rmDir($this->tempArtifact);
+    }
+
+    public function testGloballyInstalledPluginDoesNotGenerateVersionsForLocalProject()
+    {
+        $this->createPackageVersionsArtifact();
+
+        file_put_contents($this->tempGlobalComposerHome . '/composer.json', json_encode([
+            'name'         => 'package-versions/e2e-global',
+            'require'      => [
+                'ocramius/package-versions' => '1.0.0'
+            ],
+            'repositories' => [
+                [
+                    'packagist' => false,
+                ],
+                [
+                    'type' => 'artifact',
+                    'url' => $this->tempArtifact,
+                ]
+            ]
+        ], JSON_PRETTY_PRINT));
+
+        $this->exec(__DIR__ . '/../../vendor/bin/composer global update');
+
+        $this->createArtifact();
+        file_put_contents($this->tempLocalComposerHome . '/composer.json', json_encode([
+            'name'         => 'package-versions/e2e-local',
+            'require'      => [
+                'test/package' => '2.0.0'
+            ],
+            'repositories' => [
+                [
+                    'packagist' => false,
+                ],
+                [
+                    'type' => 'artifact',
+                    'url' => $this->tempArtifact,
+                ]
+            ]
+        ], JSON_PRETTY_PRINT));
+
+        $this->execInDir('composer update -vvv', $this->tempLocalComposerHome);
+
+        $this->assertFileNotExists($this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php');
+    }
+
+    private function createPackageVersionsArtifact()
+    {
+        $zip = new ZipArchive();
+
+        $zip->open($this->tempArtifact . '/ocramius-package-versions-1.0.0.zip', ZipArchive::CREATE);
+
+        $files = array_filter(
+            iterator_to_array(new RecursiveIteratorIterator(
+                new RecursiveCallbackFilterIterator(
+                    new RecursiveDirectoryIterator(realpath(__DIR__ . '/../../'), RecursiveDirectoryIterator::SKIP_DOTS),
+                    function (SplFileInfo $file) {
+                        $filePath = substr($file->getRealPath(), strlen(realpath(__DIR__ . '/../../')) + 1);
+
+                        if (substr($filePath, 0, 4) === '.git'
+                            || substr($filePath, 0, 5) === '.idea'
+                            || substr($filePath, 0, 6) === 'vendor'
+                        ) {
+                            return false;
+                        }
+
+                        return true;
+                    }
+                ),
+                RecursiveIteratorIterator::LEAVES_ONLY
+            )),
+            function (SplFileInfo $file) {
+                return !$file->isDir();
+            }
+        );
+
+        array_walk(
+            $files,
+            function (SplFileInfo $file) use ($zip) {
+                if ($file->getFilename() === 'composer.json') {
+                    $contents = json_decode(file_get_contents($file->getRealPath()), true);
+                    $contents['version'] = '1.0.0';
+
+                    return $zip->addFromString('composer.json', json_encode($contents));
+                }
+
+                $zip->addFile(
+                    $file->getRealPath(),
+                    substr($file->getRealPath(), strlen(realpath(__DIR__ . '/../../')) + 1)
+                );
+            }
+        );
+
+        $zip->close();
+    }
+
+    private function createArtifact()
+    {
+        $zip = new ZipArchive();
+
+        $zip->open($this->tempArtifact . '/test-package-2.0.0.zip', ZipArchive::CREATE);
+        $zip->addFromString('composer.json', json_encode([
+             'name'    => 'test/package',
+             'version' => '2.0.0',
+         ], JSON_PRETTY_PRINT)).
+        $zip->close();
+    }
+
+    private function execInDir(string $command, string $dir) : array
+    {
+        $currentDir = getcwd();
+        chdir($dir);
+        $output = $this->exec($command);
+        chdir($currentDir);
+        return $output;
+    }
+
+    private function exec(string $command) : array
+    {
+        exec($command . ' 2> /dev/null', $output);
+        return $output;
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return void
+     */
+    private function rmDir(string $directory)
+    {
+        if (! is_dir($directory)) {
+            unlink($directory);
+
+            return;
+        }
+
+        array_map(
+            function ($item) use ($directory) {
+                $this->rmDir($directory . '/' . $item);
+            },
+            array_filter(
+                scandir($directory),
+                function (string $dirItem) {
+                    return ! in_array($dirItem, ['.', '..'], true);
+                }
+            )
+        );
+
+        rmdir($directory);
+    }
+}

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -52,40 +52,46 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
     {
         $this->createPackageVersionsArtifact();
 
-        file_put_contents($this->tempGlobalComposerHome . '/composer.json', json_encode([
-            'name'         => 'package-versions/e2e-global',
-            'require'      => [
-                'ocramius/package-versions' => '1.0.0'
-            ],
-            'repositories' => [
-                [
-                    'packagist' => false,
+        $this->writeComposerJsonFile(
+            [
+                'name'         => 'package-versions/e2e-global',
+                'require'      => [
+                    'ocramius/package-versions' => '1.0.0'
                 ],
-                [
-                    'type' => 'artifact',
-                    'url' => $this->tempArtifact,
+                'repositories' => [
+                    [
+                        'packagist' => false,
+                    ],
+                    [
+                        'type' => 'artifact',
+                        'url' => $this->tempArtifact,
+                    ]
                 ]
-            ]
-        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            ],
+            $this->tempGlobalComposerHome
+        );
 
         $this->exec(__DIR__ . '/../../vendor/bin/composer global update');
 
         $this->createArtifact();
-        file_put_contents($this->tempLocalComposerHome . '/composer.json', json_encode([
-            'name'         => 'package-versions/e2e-local',
-            'require'      => [
-                'test/package' => '2.0.0'
-            ],
-            'repositories' => [
-                [
-                    'packagist' => false,
+        $this->writeComposerJsonFile(
+            [
+                'name'         => 'package-versions/e2e-local',
+                'require'      => [
+                    'test/package' => '2.0.0'
                 ],
-                [
-                    'type' => 'artifact',
-                    'url' => $this->tempArtifact,
+                'repositories' => [
+                    [
+                        'packagist' => false,
+                    ],
+                    [
+                        'type' => 'artifact',
+                        'url' => $this->tempArtifact,
+                    ]
                 ]
-            ]
-        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            ],
+            $this->tempLocalComposerHome
+        );
 
         $this->execInDir(__DIR__ . '/../../vendor/bin/composer update', $this->tempLocalComposerHome);
         $this->assertFileNotExists(
@@ -98,22 +104,25 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
         $this->createPackageVersionsArtifact();
         $this->createArtifact();
 
-        file_put_contents($this->tempLocalComposerHome . '/composer.json', json_encode([
-           'name'         => 'package-versions/e2e-local',
-           'require'      => [
-               'test/package' => '2.0.0',
-               'ocramius/package-versions' => '1.0.0'
-           ],
-           'repositories' => [
-               [
-                   'packagist' => false,
-               ],
-               [
-                   'type' => 'artifact',
-                   'url' => $this->tempArtifact,
-               ]
-           ]
-        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $this->writeComposerJsonFile(
+            [
+                'name'         => 'package-versions/e2e-local',
+                'require'      => [
+                    'test/package' => '2.0.0',
+                    'ocramius/package-versions' => '1.0.0'
+                ],
+                'repositories' => [
+                    [
+                        'packagist' => false,
+                    ],
+                    [
+                        'type' => 'artifact',
+                        'url' => $this->tempArtifact,
+                    ]
+                ]
+            ],
+            $this->tempLocalComposerHome
+        );
 
         $this->execInDir(__DIR__ . '/../../vendor/bin/composer update', $this->tempLocalComposerHome);
         $this->assertFileExists(
@@ -176,11 +185,25 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
         $zip = new ZipArchive();
 
         $zip->open($this->tempArtifact . '/test-package-2.0.0.zip', ZipArchive::CREATE);
-        $zip->addFromString('composer.json', json_encode([
-             'name'    => 'test/package',
-             'version' => '2.0.0',
-         ], JSON_PRETTY_PRINT)).
+        $zip->addFromString(
+            'composer.json',
+            json_encode(
+                [
+                    'name'    => 'test/package',
+                    'version' => '2.0.0'
+                ],
+                JSON_PRETTY_PRINT
+            )
+        );
         $zip->close();
+    }
+
+    private function writeComposerJsonFile(array $config, string $directory)
+    {
+        file_put_contents(
+            $directory . '/composer.json',
+            json_encode($config, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
     }
 
     private function execInDir(string $command, string $dir) : array

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -14,8 +14,19 @@ use ZipArchive;
  */
 class E2EInstaller extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var string
+     */
     private $tempGlobalComposerHome;
+
+    /**
+     * @var string
+     */
     private $tempLocalComposerHome;
+
+    /**
+     * @var string
+     */
     private $tempArtifact;
 
     public function setUp()

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -71,7 +71,7 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
             $this->tempGlobalComposerHome
         );
 
-        $this->exec(__DIR__ . '/../../vendor/bin/composer global update');
+        $this->execComposerInDir('global update', $this->tempGlobalComposerHome);
 
         $this->createArtifact();
         $this->writeComposerJsonFile(
@@ -93,7 +93,7 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
             $this->tempLocalComposerHome
         );
 
-        $this->execInDir(__DIR__ . '/../../vendor/bin/composer update', $this->tempLocalComposerHome);
+        $this->execComposerInDir('update', $this->tempLocalComposerHome);
         $this->assertFileNotExists(
             $this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php'
         );
@@ -124,15 +124,12 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
             $this->tempLocalComposerHome
         );
 
-        $this->execInDir(__DIR__ . '/../../vendor/bin/composer update', $this->tempLocalComposerHome);
+        $this->execComposerInDir('update', $this->tempLocalComposerHome);
         $this->assertFileExists(
             $this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php'
         );
 
-        $this->execInDir(
-            __DIR__ . '/../../vendor/bin/composer remove ocramius/package-versions',
-            $this->tempLocalComposerHome
-        );
+        $this->execComposerInDir('remove ocramius/package-versions', $this->tempLocalComposerHome);
 
         $this->assertFileNotExists(
             $this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php'
@@ -206,19 +203,13 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
         );
     }
 
-    private function execInDir(string $command, string $dir) : array
+    private function execComposerInDir(string $command, string $dir) : array
     {
         $currentDir = getcwd();
         chdir($dir);
-        $output = $this->exec($command);
-        chdir($currentDir);
-        return $output;
-    }
-
-    private function exec(string $command) : array
-    {
-        exec($command . ' 2> /dev/null', $output, $exitCode);
+        exec(__DIR__ . '/../../vendor/bin/composer ' . $command . ' 2> /dev/null', $output, $exitCode);
         $this->assertEquals(0, $exitCode);
+        chdir($currentDir);
         return $output;
     }
 

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -194,7 +194,8 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
 
     private function exec(string $command) : array
     {
-        exec($command . ' 2> /dev/null', $output);
+        exec($command . ' 2> /dev/null', $output, $exitCode);
+        $this->assertEquals(0, $exitCode);
         return $output;
     }
 

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -34,9 +34,9 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
         $this->tempGlobalComposerHome = sys_get_temp_dir() . '/' . uniqid('InstallerTest', true) . '/global';
         $this->tempLocalComposerHome = sys_get_temp_dir() . '/' . uniqid('InstallerTest', true) . '/local';
         $this->tempArtifact = sys_get_temp_dir() . '/' . uniqid('InstallerTest', true) . '/artifacts';
-        mkdir($this->tempGlobalComposerHome, 0777, true);
-        mkdir($this->tempLocalComposerHome, 0777, true);
-        mkdir($this->tempArtifact, 0777, true);
+        mkdir($this->tempGlobalComposerHome, 0700, true);
+        mkdir($this->tempLocalComposerHome, 0700, true);
+        mkdir($this->tempArtifact, 0700, true);
 
         putenv('COMPOSER_HOME=' . $this->tempGlobalComposerHome);
     }

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -87,7 +87,7 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
             ]
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-        $this->execInDir('composer update', $this->tempLocalComposerHome);
+        $this->execInDir(__DIR__ . '/../../vendor/bin/composer update', $this->tempLocalComposerHome);
         $this->assertFileNotExists(
             $this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php'
         );
@@ -115,12 +115,16 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
            ]
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-        $this->execInDir('composer update -vvv', $this->tempLocalComposerHome);
+        $this->execInDir(__DIR__ . '/../../vendor/bin/composer update', $this->tempLocalComposerHome);
         $this->assertFileExists(
             $this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php'
         );
 
-        $this->execInDir('composer remove ocramius/package-versions -vvv', $this->tempLocalComposerHome);
+        $this->execInDir(
+            __DIR__ . '/../../vendor/bin/composer remove ocramius/package-versions',
+            $this->tempLocalComposerHome
+        );
+
         $this->assertFileNotExists(
             $this->tempLocalComposerHome . '/vendor/ocramius/package-versions/src/PackageVersions/Versions.php'
         );

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -10,7 +10,7 @@ use SplFileInfo;
 use ZipArchive;
 
 /**
- * @author Aydin Hassan <aydin@hotmail.co.uk>
+ * @coversNothing
  */
 class E2EInstaller extends PHPUnit_Framework_TestCase
 {

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -46,6 +46,8 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
         $this->rmDir($this->tempGlobalComposerHome);
         $this->rmDir($this->tempLocalComposerHome);
         $this->rmDir($this->tempArtifact);
+
+        putenv('COMPOSER_HOME');
     }
 
     public function testGloballyInstalledPluginDoesNotGenerateVersionsForLocalProject()

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -113,7 +113,7 @@ class E2EInstaller extends PHPUnit_Framework_TestCase
                    'url' => $this->tempArtifact,
                ]
            ]
-       ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
         $this->execInDir('composer update -vvv', $this->tempLocalComposerHome);
         $this->assertFileExists(


### PR DESCRIPTION
I had to refactor a little to reduce repeating code, anyway this fixes #38.

However, I've had a think and I don't know how we can provide an e2e test. We could provide some project assets but we'd have to mess with the systems global composer project, which I don't think we can do safely.

I've also had to modify existing tests, I wasn't sure how to get them working now that we need `ocramius/package-versions` to be present in the locker.

Thoughts @Ocramius ?
