### PR TITLE
Surpress chmod warnings

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -124,7 +124,7 @@ PHP;
         $io->write('<info>ocramius/package-versions:</info>  Generating version class...');
 
         file_put_contents($installPath, $versionClassSource);
-        chmod($installPath, 0664);
+        @chmod($installPath, 0664);
 
         $io->write('<info>ocramius/package-versions:</info> ...done generating version class');
     }


### PR DESCRIPTION
See https://github.com/doctrine/common/issues/381

This avoids the error `chmod(): Operation not permitted` when your current user has not created the file but is in the same group.