### PR TITLE
Ignore possible permission error during version class generation

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -124,7 +124,7 @@ PHP;
         $io->write('<info>ocramius/package-versions:</info>  Generating version class...');
 
         file_put_contents($installPath, $versionClassSource);
-        chmod($installPath, 0664);
+        @chmod($installPath, 0664);
 
         $io->write('<info>ocramius/package-versions:</info> ...done generating version class');
     }


### PR DESCRIPTION
File might be originaly owned by someone else and chmod might fail but that doesn't mean the whole process should fail and terminate whole composer install.