### PR TITLE
Delete class file prior to writing it to ensure permissions

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -118,6 +118,11 @@ PHP;
 
         $io->write('<info>ocramius/package-versions:</info>  Generating version class...');
 
+        // Delete the file prior writing the new file to ensure proper user/group setting of the file
+        if(file_exists($installPath)) {
+            unlink($installPath);
+        }
+        
         file_put_contents($installPath, $versionClassSource);
         chmod($installPath, 0664);
 


### PR DESCRIPTION
Alternative for #47 with the same effect if you have a proper permission setup.

Eventually you can accept this as this does nothing other than deleting the file.