### PR TITLE
Remove rude message in case of lock file not found

### DIFF
--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -58,7 +58,7 @@ final class FallbackVersions
         throw new \UnexpectedValueException(sprintf(
             'PackageVersions could not locate your `composer.lock` location. This is assumed to be in %s. '
             . 'If you customized your composer vendor directory and ran composer installation with --no-scripts, '
-            . 'then you are on your own, and we can\'t really help you. Fix your shit and cut the tooling some slack.',
+            . 'then you are on your own, and we can\'t really help you.',
             json_encode($checkedPaths)
         ));
     }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -26,8 +26,7 @@ final class FallbackVersionsTest extends TestCase
                 . 'This is assumed to be in '
                 . json_encode([$srcDir . '/../../../../../composer.lock', $srcDir . '/../../composer.lock'])
                 . '. If you customized your composer vendor directory and ran composer installation with --no-scripts, '
-                . 'then you are on your own, and we can\'t really help you. '
-                . 'Fix your shit and cut the tooling some slack.',
+                . 'then you are on your own, and we can\'t really help you.',
                 $lockFileNotFound->getMessage()
             );
         } finally {


### PR DESCRIPTION
I propose to remove this rude part of the message and make focus on the real issue in case of `composer.lock` file not found.