### PR TITLE
Test against PHP 7.3 and 7.4snapshot, drop nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: false
 php:
   - 7.1
   - 7.2
-  - nightly
+  - 7.3
+  - 7.4snapshot
 
 env:
   - DEPENDENCIES=""


### PR DESCRIPTION
This should be a trivial fix for the recent `nightly` issue (popped up in #65), without allowing mystical 8.0-dev in composer.json.