### PR TITLE
fixed spacing

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -137,7 +137,7 @@ PHP;
             return;
         }
 
-        $io->write('<info>ocramius/package-versions:</info>  Generating version class...');
+        $io->write('<info>ocramius/package-versions:</info> Generating version class...');
 
         $installPathTmp = $installPath . '_' . uniqid('tmp', true);
         file_put_contents($installPathTmp, $versionClassSource);


### PR DESCRIPTION
Running a composer update with this lib included renders a message into the console.

this message has 1 space to much on the left, which will be removed with this PR:

![grafik](https://user-images.githubusercontent.com/120441/54034455-2d84a880-41b7-11e9-92d6-2d47f53a2ab8.png)
