### PR TITLE
added docs to Versions::VERSION

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -48,6 +48,12 @@ namespace PackageVersions;
 %s
 {
     public const ROOT_PACKAGE_NAME = '%s';
+    /**
+     * Array of all available composer packages.
+     * Dont read this array from your calling code, but use the \PackageVersions\Versions::getVersion() method instead.
+     *
+     * @internal
+     */
     public const VERSIONS          = %s;
 
     private function __construct()

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -52,6 +52,7 @@ namespace PackageVersions;
      * Array of all available composer packages.
      * Dont read this array from your calling code, but use the \PackageVersions\Versions::getVersion() method instead.
      *
+     * @var array<string, string>
      * @internal
      */
     public const VERSIONS          = %s;

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -222,6 +222,13 @@ namespace PackageVersions;
 final class Versions
 {
     public const ROOT_PACKAGE_NAME = 'root/package';
+    /**
+     * Array of all available composer packages.
+     * Dont read this array from your calling code, but use the \PackageVersions\Versions::getVersion() method instead.
+     *
+     * @var array<string, string>
+     * @internal
+     */
     public const VERSIONS          = array (
   'ocramius/package-versions' => '1.0.0@',
   'foo/bar' => '1.2.3@abc123',
@@ -326,6 +333,13 @@ namespace PackageVersions;
 final class Versions
 {
     public const ROOT_PACKAGE_NAME = 'root/package';
+    /**
+     * Array of all available composer packages.
+     * Dont read this array from your calling code, but use the \PackageVersions\Versions::getVersion() method instead.
+     *
+     * @var array<string, string>
+     * @internal
+     */
     public const VERSIONS          = array (
   'ocramius/package-versions' => '1.0.0@',
   'foo/bar' => '1.2.3@abc123',
@@ -433,6 +447,13 @@ namespace PackageVersions;
 final class Versions
 {
     public const ROOT_PACKAGE_NAME = 'root/package';
+    /**
+     * Array of all available composer packages.
+     * Dont read this array from your calling code, but use the \PackageVersions\Versions::getVersion() method instead.
+     *
+     * @var array<string, string>
+     * @internal
+     */
     public const VERSIONS          = array (
   'ocramius/package-versions' => '1.0.0@',
   'foo/bar' => '1.2.3@abc123',
@@ -834,6 +855,13 @@ namespace PackageVersions;
 final class Versions
 {
     public const ROOT_PACKAGE_NAME = 'root/package';
+    /**
+     * Array of all available composer packages.
+     * Dont read this array from your calling code, but use the \PackageVersions\Versions::getVersion() method instead.
+     *
+     * @var array<string, string>
+     * @internal
+     */
     public const VERSIONS          = array (
   'ocramius/package-versions' => '1.0.0@',
   'some-replaced/package' => '1.3.5@aaabbbcccddd',


### PR DESCRIPTION
the constant is public for technical reasons, therefore should be documented as `@internal`.

Added a hint for the public api to use