### PR TITLE
Use vendor/composer/installed.json and fallback to using composer.lock

### DIFF
--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -42,7 +42,7 @@ final class FallbackVersions
 
         if (! array_key_exists($packageName, $versions)) {
             throw new OutOfBoundsException(
-                'Required package "' . $packageName . '" is not installed: cannot detect its version'
+                'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
             );
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -54,8 +54,14 @@ final class FallbackVersions
      */
     private static function getComposerLockPath() : string
     {
-        // bold assumption, but there's not here to fix everyone's problems.
-        $checkedPaths = [__DIR__ . '/../../../../../composer.lock', __DIR__ . '/../../composer.lock'];
+        $checkedPaths = [
+            // The top-level project's ./vendor/composer/installed.json
+            getcwd() . '/vendor/composer/installed.json',
+            // The top-level project's ./composer.lock
+            getcwd() . '/composer.lock',
+            // This package's composer.lock
+            __DIR__ . '/../../composer.lock',
+        ];
 
         foreach ($checkedPaths as $path) {
             if (file_exists($path)) {

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -81,7 +81,7 @@ final class FallbackVersions
             }
         }
 
-        if (!empty($packageData)) {
+        if ($packageData !== []) {
             return array_merge(...$packageData);
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -11,6 +11,7 @@ use function array_key_exists;
 use function array_merge;
 use function file_exists;
 use function file_get_contents;
+use function getcwd;
 use function iterator_to_array;
 use function json_decode;
 use function json_encode;
@@ -33,8 +34,6 @@ final class FallbackVersions
     }
 
     /**
-     * @param string $packageName
-     * @return string
      * @throws OutOfBoundsException If a version cannot be located.
      * @throws UnexpectedValueException If the composer.lock file could not be located.
      */

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -33,6 +33,8 @@ final class FallbackVersions
     }
 
     /**
+     * @param string $packageName
+     * @return string
      * @throws OutOfBoundsException If a version cannot be located.
      * @throws UnexpectedValueException If the composer.lock file could not be located.
      */

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -82,11 +82,14 @@ final class FallbackVersions
     {
         $lockData = json_decode(file_get_contents($composerLockFile), true);
 
-        $lockData['packages-dev'] = $lockData['packages-dev'] ?? [];
+        if (array_key_exists('content-hash', $lockData)) {
+            // assume a composer.lock file and merge the packages and packages-dev into an array
+            $lockData = array_merge($lockData['packages'], $lockData['packages-dev'] ?? []);
+        }
 
-        foreach (array_merge($lockData['packages'], $lockData['packages-dev']) as $package) {
+        foreach ($lockData as $package) {
             yield $package['name'] => $package['version'] . '@' . (
-                $package['source']['reference']?? $package['dist']['reference'] ?? ''
+                $package['source']['reference'] ?? $package['dist']['reference'] ?? ''
             );
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -64,9 +64,10 @@ final class FallbackVersions
         }
 
         throw new UnexpectedValueException(sprintf(
-            'PackageVersions could not locate your `composer.lock` location. This is assumed to be in %s. '
-            . 'If you customized your composer vendor directory and ran composer installation with --no-scripts, '
-            . 'then you are on your own, and we can\'t really help you. Fix your shit and cut the tooling some slack.',
+            'PackageVersions could not locate the `vendor/composer/installed.json` or your `composer.lock` '
+            . 'location. This is assumed to be in %s. If you customized your composer vendor directory and ran composer '
+            . 'installation with --no-scripts or if you deployed without the required composer files, then you are on '
+            . 'your own, and we can\'t really help you. Fix your shit and cut the tooling some slack.',
             json_encode($checkedPaths)
         ));
     }

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -64,18 +64,25 @@ final class FallbackVersions
             __DIR__ . '/../../composer.lock',
         ];
 
+        $packageData = [];
         foreach ($checkedPaths as $path) {
             if (file_exists($path)) {
+                $data = json_decode(file_get_contents($path), true);
                 switch (basename($path)) {
                     case 'installed.json':
-                        return json_decode(file_get_contents($path), true);
+                        $packageData[] = $data;
+                        break;
                     case 'composer.lock':
-                        $data = json_decode(file_get_contents($path), true);
-                        return array_merge($data['packages'], $data['packages-dev'] ?? []);
+                        $packageData[] = $data['packages'] + ($data['packages-dev'] ?? []);
+                        break;
                     default:
                         // intentionally left blank
                 }
             }
+        }
+
+        if (!empty($packageData)) {
+            return array_merge(...$packageData);
         }
 
         throw new UnexpectedValueException(sprintf(

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -73,7 +73,7 @@ namespace PackageVersions;
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -20,7 +20,7 @@ use function uniqid;
  */
 final class FallbackVersionsTest extends TestCase
 {
-    public function testWillFailWithoutValidComposerLockLocation() : void
+    public function testWillFailWithoutValidPackageData() : void
     {
         $this->backupFile(__DIR__ . '/../../vendor/composer/installed.json');
         $this->backupFile(__DIR__ . '/../../composer.lock');
@@ -61,6 +61,21 @@ final class FallbackVersionsTest extends TestCase
         self::assertNotEmpty($packages);
 
         $this->backupFile(__DIR__ . '/../../composer.lock');
+        foreach ($packages as $package) {
+            self::assertSame(
+                $package['version'] . '@' . $package['source']['reference'],
+                FallbackVersions::getVersion($package['name'])
+            );
+        }
+    }
+
+    public function testValidVersionsWithoutInstalledJson() : void
+    {
+        $packages = json_decode(file_get_contents(__DIR__ . '/../../vendor/composer/installed.json'), true);
+
+        self::assertNotEmpty($packages);
+
+        $this->backupFile(__DIR__ . '/../../vendor/composer/installed.json');
         foreach ($packages as $package) {
             self::assertSame(
                 $package['version'] . '@' . $package['source']['reference'],

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -9,10 +9,9 @@ use PackageVersions\FallbackVersions;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use function array_merge;
+use function file_exists;
 use function file_get_contents;
 use function json_decode;
-use function json_encode;
-use function realpath;
 use function rename;
 use function uniqid;
 
@@ -26,7 +25,7 @@ final class FallbackVersionsTest extends TestCase
         rename(__DIR__ . '/../../vendor/composer/installed.json', __DIR__ . '/../../vendor/composer/installed.json.backup');
         rename(__DIR__ . '/../../composer.lock', __DIR__ . '/../../composer.lock.backup');
 
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageRegExp(
             '@PackageVersions could not locate the `vendor/composer/installed\.json` or your `composer\.lock` '
             . 'location\. This is assumed to be in \[[^]]+?\]\. If you customized your composer vendor directory and ran composer '
@@ -60,14 +59,13 @@ final class FallbackVersionsTest extends TestCase
         FallbackVersions::getVersion(uniqid('', true) . '/' . uniqid('', true));
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
-        if (file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup')) {
-            rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
+        if (! file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup') && ! file_exists(__DIR__ . '/../../composer.lock.backup')) {
+            return;
         }
 
-        if (file_exists(__DIR__ . '/../../composer.lock.backup')) {
-            rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
-        }
+        rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
+        rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -22,8 +22,8 @@ final class FallbackVersionsTest extends TestCase
 {
     public function testWillFailWithoutValidComposerLockLocation() : void
     {
-        rename(__DIR__ . '/../../vendor/composer/installed.json', __DIR__ . '/../../vendor/composer/installed.json.backup');
-        rename(__DIR__ . '/../../composer.lock', __DIR__ . '/../../composer.lock.backup');
+        $this->backupFile(__DIR__ . '/../../vendor/composer/installed.json');
+        $this->backupFile(__DIR__ . '/../../composer.lock');
 
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageRegExp(
@@ -61,11 +61,21 @@ final class FallbackVersionsTest extends TestCase
 
     protected function tearDown() : void
     {
-        if (! file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup') && ! file_exists(__DIR__ . '/../../composer.lock.backup')) {
+        $this->revertFile(__DIR__ . '/../../composer.lock');
+        $this->revertFile(__DIR__ . '/../../vendor/composer/installed.json');
+    }
+
+    private function backupFile(string $filename) : void
+    {
+        rename($filename, $filename . '.backup');
+    }
+
+    private function revertFile(string $filename) : void
+    {
+        if (! file_exists($filename . '.backup')) {
             return;
         }
 
-        rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
-        rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
+        rename($filename . '.backup', $filename);
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -52,6 +52,23 @@ final class FallbackVersionsTest extends TestCase
         }
     }
 
+    public function testValidVersionsWithoutComposerLock() : void
+    {
+        $lockData = json_decode(file_get_contents(__DIR__ . '/../../composer.lock'), true);
+
+        $packages = array_merge($lockData['packages'], $lockData['packages-dev']);
+
+        self::assertNotEmpty($packages);
+
+        $this->backupFile(__DIR__ . '/../../composer.lock');
+        foreach ($packages as $package) {
+            self::assertSame(
+                $package['version'] . '@' . $package['source']['reference'],
+                FallbackVersions::getVersion($package['name'])
+            );
+        }
+    }
+
     public function testInvalidVersionsAreRejected() : void
     {
         $this->expectException(OutOfBoundsException::class);

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -23,27 +23,18 @@ final class FallbackVersionsTest extends TestCase
 {
     public function testWillFailWithoutValidComposerLockLocation() : void
     {
+        rename(__DIR__ . '/../../vendor/composer/installed.json', __DIR__ . '/../../vendor/composer/installed.json.backup');
         rename(__DIR__ . '/../../composer.lock', __DIR__ . '/../../composer.lock.backup');
 
-        try {
-            FallbackVersions::getVersion('phpunit/phpunit');
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessageRegExp(
+            '@PackageVersions could not locate the `vendor/composer/installed\.json` or your `composer\.lock` '
+            . 'location\. This is assumed to be in \[[^]]+?\]\. If you customized your composer vendor directory and ran composer '
+            . 'installation with --no-scripts or if you deployed without the required composer files, then you are on '
+            . 'your own, and we can\'t really help you\. Fix your shit and cut the tooling some slack\.@'
+        );
 
-            self::fail('An exception was supposed to be thrown');
-        } catch (UnexpectedValueException $lockFileNotFound) {
-            $srcDir = realpath(__DIR__ . '/../../src/PackageVersions');
-
-            self::assertSame(
-                'PackageVersions could not locate your `composer.lock` location. '
-                . 'This is assumed to be in '
-                . json_encode([$srcDir . '/../../../../../composer.lock', $srcDir . '/../../composer.lock'])
-                . '. If you customized your composer vendor directory and ran composer installation with --no-scripts, '
-                . 'then you are on your own, and we can\'t really help you. '
-                . 'Fix your shit and cut the tooling some slack.',
-                $lockFileNotFound->getMessage()
-            );
-        } finally {
-            rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
-        }
+        FallbackVersions::getVersion('phpunit/phpunit');
     }
 
     public function testValidVersions() : void
@@ -67,5 +58,16 @@ final class FallbackVersionsTest extends TestCase
         $this->expectException(OutOfBoundsException::class);
 
         FallbackVersions::getVersion(uniqid('', true) . '/' . uniqid('', true));
+    }
+
+    protected function tearDown()
+    {
+        if (file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup')) {
+            rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
+        }
+
+        if (file_exists(__DIR__ . '/../../composer.lock.backup')) {
+            rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
+        }
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -54,12 +54,6 @@ final class FallbackVersionsTest extends TestCase
 
     public function testValidVersionsWithoutComposerLock() : void
     {
-        // This test will always fail if there is nothing in the installed.json
-        // due to this package being installed with `composer install --no-dev`.
-        if (json_decode(file_get_contents(getcwd() . '/vendor/composer/installed.json', true)) === []) {
-            $this->markTestSkipped('Empty installed.json (possible --no-dev)');
-        }
-
         $lockData = json_decode(file_get_contents(__DIR__ . '/../../composer.lock'), true);
 
         $packages = array_merge($lockData['packages'], $lockData['packages-dev'] ?? []);

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -253,7 +253,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }
@@ -365,7 +365,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }
@@ -481,7 +481,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }
@@ -889,7 +889,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }


### PR DESCRIPTION
Also be more clear in the messages why the exceptions are being thrown so that developers understand what files are being looked in for package versions. In other words, we know to deploy the `vendor/composer/installed.json` and/or the `composer.lock` for the project.