### PR TITLE
Provide `@psalm-param key-of<self::VERSIONS>` type-check for downstream

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -63,6 +63,8 @@ namespace PackageVersions;
 
     /**
      * @throws \OutOfBoundsException If a version cannot be located.
+     *
+     * @psalm-param key-of<self::VERSIONS> $packageName
      */
     public static function getVersion(string $packageName) : string
     {

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -244,6 +244,8 @@ final class Versions
 
     /**
      * @throws \OutOfBoundsException If a version cannot be located.
+     *
+     * @psalm-param key-of<self::VERSIONS> $packageName
      */
     public static function getVersion(string $packageName) : string
     {
@@ -354,6 +356,8 @@ final class Versions
 
     /**
      * @throws \OutOfBoundsException If a version cannot be located.
+     *
+     * @psalm-param key-of<self::VERSIONS> $packageName
      */
     public static function getVersion(string $packageName) : string
     {
@@ -468,6 +472,8 @@ final class Versions
 
     /**
      * @throws \OutOfBoundsException If a version cannot be located.
+     *
+     * @psalm-param key-of<self::VERSIONS> $packageName
      */
     public static function getVersion(string $packageName) : string
     {
@@ -874,6 +880,8 @@ final class Versions
 
     /**
      * @throws \OutOfBoundsException If a version cannot be located.
+     *
+     * @psalm-param key-of<self::VERSIONS> $packageName
      */
     public static function getVersion(string $packageName) : string
     {


### PR DESCRIPTION
As described by @muglug in https://github.com/vimeo/psalm/releases/tag/3.3.1, it is now possible to statically check parameters given to `PackageVersions\Versions::getVersion()`.

@malukenho what do you think of this?

Few questions are open for discussion here:

 1. do we care about dynamic package names? Calls like `PackageVersions\Versions::getVersion($aString)` will now fail if downstream won't force it to be an `/** @var key-of \PackageVersions\Versions::VERSIONS $aString */`
 2. Do we still need the `\OutOfBoundsException`, if the access can be statically checked?