### PR TITLE
dump the version class on "composer dump-autoload"

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -96,6 +96,7 @@ PHP;
         return [
             ScriptEvents::POST_INSTALL_CMD => 'dumpVersionsClass',
             ScriptEvents::POST_UPDATE_CMD  => 'dumpVersionsClass',
+            ScriptEvents::POST_AUTOLOAD_DUMP  => 'dumpVersionsClass',
         ];
     }
 

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -86,7 +86,7 @@ final class InstallerTest extends TestCase
             [
                 'post-install-cmd' => 'dumpVersionsClass',
                 'post-update-cmd'  => 'dumpVersionsClass',
-                'post-autoload-dump' => 'dumpVersionsClass'
+                'post-autoload-dump' => 'dumpVersionsClass',
             ],
             $events
         );

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -86,6 +86,7 @@ final class InstallerTest extends TestCase
             [
                 'post-install-cmd' => 'dumpVersionsClass',
                 'post-update-cmd'  => 'dumpVersionsClass',
+                'post-autoload-dump' => 'dumpVersionsClass'
             ],
             $events
         );


### PR DESCRIPTION
the Readme describes that you should use the `--optimize` flag when dumping the autoloader.

this package does not yet hook into the dumping of autoloader when `composer dump-autoload` is used.

this PR adds support for class regeneration on `composer dump-autoload`.
we need this, since we use `composer install ... --no-scripts` in the CI pipeline and want to dump the autoloader on its own.