### PR TITLE
the POST_AUTOLOAD_DUMP event also happens on composer install/update

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -94,8 +94,6 @@ PHP;
     public static function getSubscribedEvents() : array
     {
         return [
-            ScriptEvents::POST_INSTALL_CMD => 'dumpVersionsClass',
-            ScriptEvents::POST_UPDATE_CMD  => 'dumpVersionsClass',
             ScriptEvents::POST_AUTOLOAD_DUMP  => 'dumpVersionsClass',
         ];
     }

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -84,8 +84,6 @@ final class InstallerTest extends TestCase
 
         self::assertSame(
             [
-                'post-install-cmd' => 'dumpVersionsClass',
-                'post-update-cmd'  => 'dumpVersionsClass',
                 'post-autoload-dump' => 'dumpVersionsClass',
             ],
             $events


### PR DESCRIPTION
no need to subscribe to install/update and autoload-dump.

fixes https://github.com/Ocramius/PackageVersions/issues/94