### PR TITLE
#101 corrected scanned locations for `installed.json` and `composer.json`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
   - DEPENDENCIES="--no-scripts"
 
 before_script:
+  # aliasing current branch as `master`, since otherwise composer cannot determine the current branch-alias
+  - git branch -D master || true
+  - git checkout -b master
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -61,8 +61,10 @@ final class FallbackVersions
         $checkedPaths = [
             // The top-level project's ./vendor/composer/installed.json
             getcwd() . '/vendor/composer/installed.json',
+            __DIR__ . '/../../../../composer/installed.json',
             // The top-level project's ./composer.lock
             getcwd() . '/composer.lock',
+            __DIR__ . '/../../../../../composer.lock',
             // This package's composer.lock
             __DIR__ . '/../../composer.lock',
         ];

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -12,10 +12,12 @@ use SplFileInfo;
 use ZipArchive;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
+use const PHP_BINARY;
 use function array_filter;
 use function array_map;
 use function array_walk;
 use function chdir;
+use function escapeshellarg;
 use function exec;
 use function file_get_contents;
 use function file_put_contents;
@@ -298,7 +300,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 echo \PackageVersions\Versions::getVersion('ocramius/package-versions');
 PHP
-
         );
     }
 


### PR DESCRIPTION
Due to `getcwd()` returning an empty string in some environments, (or even `"."`, a dot, sometimes), this fallback versions logic was too fragile.

Adding hardcoded paths that are supposed to be constant (relative to the installation path of `FallbackVersions.php`) gives us more stability.

Fixes #101