### PR TITLE
Backport #82 to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer-plugin-api": "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit":          "^7.0.0",
+        "phpunit/phpunit":          "^7.5.17",
         "infection/infection":      "^0.7.1",
         "composer/composer":        "^1.6.3",
         "ext-zip":                  "*",

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -42,7 +42,7 @@ final class FallbackVersions
 
         if (! array_key_exists($packageName, $versions)) {
             throw new OutOfBoundsException(
-                'Required package "' . $packageName . '" is not installed: cannot detect its version'
+                'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
             );
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -54,8 +54,14 @@ final class FallbackVersions
      */
     private static function getComposerLockPath() : string
     {
-        // bold assumption, but there's not here to fix everyone's problems.
-        $checkedPaths = [__DIR__ . '/../../../../../composer.lock', __DIR__ . '/../../composer.lock'];
+        $checkedPaths = [
+            // The top-level project's ./vendor/composer/installed.json
+            getcwd() . '/vendor/composer/installed.json',
+            // The top-level project's ./composer.lock
+            getcwd() . '/composer.lock',
+            // This package's composer.lock
+            __DIR__ . '/../../composer.lock',
+        ];
 
         foreach ($checkedPaths as $path) {
             if (file_exists($path)) {

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -81,7 +81,7 @@ final class FallbackVersions
             }
         }
 
-        if (!empty($packageData)) {
+        if ($packageData !== []) {
             return array_merge(...$packageData);
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -11,6 +11,7 @@ use function array_key_exists;
 use function array_merge;
 use function file_exists;
 use function file_get_contents;
+use function getcwd;
 use function iterator_to_array;
 use function json_decode;
 use function json_encode;
@@ -33,8 +34,6 @@ final class FallbackVersions
     }
 
     /**
-     * @param string $packageName
-     * @return string
      * @throws OutOfBoundsException If a version cannot be located.
      * @throws UnexpectedValueException If the composer.lock file could not be located.
      */

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -33,6 +33,8 @@ final class FallbackVersions
     }
 
     /**
+     * @param string $packageName
+     * @return string
      * @throws OutOfBoundsException If a version cannot be located.
      * @throws UnexpectedValueException If the composer.lock file could not be located.
      */

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -9,6 +9,7 @@ use OutOfBoundsException;
 use UnexpectedValueException;
 use function array_key_exists;
 use function array_merge;
+use function basename;
 use function file_exists;
 use function file_get_contents;
 use function getcwd;
@@ -68,18 +69,20 @@ final class FallbackVersions
 
         $packageData = [];
         foreach ($checkedPaths as $path) {
-            if (file_exists($path)) {
-                $data = json_decode(file_get_contents($path), true);
-                switch (basename($path)) {
-                    case 'installed.json':
-                        $packageData[] = $data;
-                        break;
-                    case 'composer.lock':
-                        $packageData[] = $data['packages'] + ($data['packages-dev'] ?? []);
-                        break;
-                    default:
-                        // intentionally left blank
-                }
+            if (! file_exists($path)) {
+                continue;
+            }
+
+            $data = json_decode(file_get_contents($path), true);
+            switch (basename($path)) {
+                case 'installed.json':
+                    $packageData[] = $data;
+                    break;
+                case 'composer.lock':
+                    $packageData[] = $data['packages'] + ($data['packages-dev'] ?? []);
+                    break;
+                default:
+                    // intentionally left blank
             }
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -82,11 +82,14 @@ final class FallbackVersions
     {
         $lockData = json_decode(file_get_contents($composerLockFile), true);
 
-        $lockData['packages-dev'] = $lockData['packages-dev'] ?? [];
+        if (array_key_exists('content-hash', $lockData)) {
+            // assume a composer.lock file and merge the packages and packages-dev into an array
+            $lockData = array_merge($lockData['packages'], $lockData['packages-dev'] ?? []);
+        }
 
-        foreach (array_merge($lockData['packages'], $lockData['packages-dev']) as $package) {
+        foreach ($lockData as $package) {
             yield $package['name'] => $package['version'] . '@' . (
-                $package['source']['reference']?? $package['dist']['reference'] ?? ''
+                $package['source']['reference'] ?? $package['dist']['reference'] ?? ''
             );
         }
 

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -51,6 +51,8 @@ final class FallbackVersions
     }
 
     /**
+     * @return mixed[]
+     *
      * @throws UnexpectedValueException
      */
     private static function getPackageData() : array
@@ -94,6 +96,13 @@ final class FallbackVersions
         ));
     }
 
+    /**
+     * @param mixed[] $packageData
+     *
+     * @return Generator&string[]
+     *
+     * @psalm-return Generator<string, string>
+     */
     private static function getVersions(array $packageData) : Generator
     {
         foreach ($packageData as $package) {
@@ -102,6 +111,6 @@ final class FallbackVersions
             );
         }
 
-        yield self::ROOT_PACKAGE_NAME;
+        yield self::ROOT_PACKAGE_NAME => self::ROOT_PACKAGE_NAME;
     }
 }

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -64,9 +64,10 @@ final class FallbackVersions
         }
 
         throw new UnexpectedValueException(sprintf(
-            'PackageVersions could not locate your `composer.lock` location. This is assumed to be in %s. '
-            . 'If you customized your composer vendor directory and ran composer installation with --no-scripts, '
-            . 'then you are on your own, and we can\'t really help you. Fix your shit and cut the tooling some slack.',
+            'PackageVersions could not locate the `vendor/composer/installed.json` or your `composer.lock` '
+            . 'location. This is assumed to be in %s. If you customized your composer vendor directory and ran composer '
+            . 'installation with --no-scripts or if you deployed without the required composer files, then you are on '
+            . 'your own, and we can\'t really help you. Fix your shit and cut the tooling some slack.',
             json_encode($checkedPaths)
         ));
     }

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -64,18 +64,25 @@ final class FallbackVersions
             __DIR__ . '/../../composer.lock',
         ];
 
+        $packageData = [];
         foreach ($checkedPaths as $path) {
             if (file_exists($path)) {
+                $data = json_decode(file_get_contents($path), true);
                 switch (basename($path)) {
                     case 'installed.json':
-                        return json_decode(file_get_contents($path), true);
+                        $packageData[] = $data;
+                        break;
                     case 'composer.lock':
-                        $data = json_decode(file_get_contents($path), true);
-                        return array_merge($data['packages'], $data['packages-dev'] ?? []);
+                        $packageData[] = $data['packages'] + ($data['packages-dev'] ?? []);
+                        break;
                     default:
                         // intentionally left blank
                 }
             }
+        }
+
+        if (!empty($packageData)) {
+            return array_merge(...$packageData);
         }
 
         throw new UnexpectedValueException(sprintf(

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -64,7 +64,7 @@ namespace PackageVersions;
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -20,7 +20,7 @@ use function uniqid;
  */
 final class FallbackVersionsTest extends TestCase
 {
-    public function testWillFailWithoutValidComposerLockLocation() : void
+    public function testWillFailWithoutValidPackageData() : void
     {
         $this->backupFile(__DIR__ . '/../../vendor/composer/installed.json');
         $this->backupFile(__DIR__ . '/../../composer.lock');
@@ -61,6 +61,21 @@ final class FallbackVersionsTest extends TestCase
         self::assertNotEmpty($packages);
 
         $this->backupFile(__DIR__ . '/../../composer.lock');
+        foreach ($packages as $package) {
+            self::assertSame(
+                $package['version'] . '@' . $package['source']['reference'],
+                FallbackVersions::getVersion($package['name'])
+            );
+        }
+    }
+
+    public function testValidVersionsWithoutInstalledJson() : void
+    {
+        $packages = json_decode(file_get_contents(__DIR__ . '/../../vendor/composer/installed.json'), true);
+
+        self::assertNotEmpty($packages);
+
+        $this->backupFile(__DIR__ . '/../../vendor/composer/installed.json');
         foreach ($packages as $package) {
             self::assertSame(
                 $package['version'] . '@' . $package['source']['reference'],

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -9,10 +9,9 @@ use PackageVersions\FallbackVersions;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use function array_merge;
+use function file_exists;
 use function file_get_contents;
 use function json_decode;
-use function json_encode;
-use function realpath;
 use function rename;
 use function uniqid;
 
@@ -26,7 +25,7 @@ final class FallbackVersionsTest extends TestCase
         rename(__DIR__ . '/../../vendor/composer/installed.json', __DIR__ . '/../../vendor/composer/installed.json.backup');
         rename(__DIR__ . '/../../composer.lock', __DIR__ . '/../../composer.lock.backup');
 
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageRegExp(
             '@PackageVersions could not locate the `vendor/composer/installed\.json` or your `composer\.lock` '
             . 'location\. This is assumed to be in \[[^]]+?\]\. If you customized your composer vendor directory and ran composer '
@@ -60,14 +59,13 @@ final class FallbackVersionsTest extends TestCase
         FallbackVersions::getVersion(uniqid('', true) . '/' . uniqid('', true));
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
-        if (file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup')) {
-            rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
+        if (! file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup') && ! file_exists(__DIR__ . '/../../composer.lock.backup')) {
+            return;
         }
 
-        if (file_exists(__DIR__ . '/../../composer.lock.backup')) {
-            rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
-        }
+        rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
+        rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -71,10 +71,12 @@ final class FallbackVersionsTest extends TestCase
 
     public function testValidVersionsWithoutInstalledJson() : void
     {
-        if (($packages = json_decode(file_get_contents(__DIR__ . '/../../vendor/composer/installed.json'), true)) === []) {
+        $packages = json_decode(file_get_contents(__DIR__ . '/../../vendor/composer/installed.json'), true);
+
+        if ($packages === []) {
             // In case of --no-dev flag
-            $packages = json_decode(file_get_contents(getcwd() . '/composer.lock'), true);
-            $packages = array_merge($packages['packages'], $packages['packages-dev'] ?? []);
+            $lockData = json_decode(file_get_contents(getcwd() . '/composer.lock'), true);
+            $packages = array_merge($lockData['packages'], $lockData['packages-dev'] ?? []);
         }
 
         self::assertNotEmpty($packages);

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -22,8 +22,8 @@ final class FallbackVersionsTest extends TestCase
 {
     public function testWillFailWithoutValidComposerLockLocation() : void
     {
-        rename(__DIR__ . '/../../vendor/composer/installed.json', __DIR__ . '/../../vendor/composer/installed.json.backup');
-        rename(__DIR__ . '/../../composer.lock', __DIR__ . '/../../composer.lock.backup');
+        $this->backupFile(__DIR__ . '/../../vendor/composer/installed.json');
+        $this->backupFile(__DIR__ . '/../../composer.lock');
 
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessageRegExp(
@@ -61,11 +61,21 @@ final class FallbackVersionsTest extends TestCase
 
     protected function tearDown() : void
     {
-        if (! file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup') && ! file_exists(__DIR__ . '/../../composer.lock.backup')) {
+        $this->revertFile(__DIR__ . '/../../composer.lock');
+        $this->revertFile(__DIR__ . '/../../vendor/composer/installed.json');
+    }
+
+    private function backupFile(string $filename) : void
+    {
+        rename($filename, $filename . '.backup');
+    }
+
+    private function revertFile(string $filename) : void
+    {
+        if (! file_exists($filename . '.backup')) {
             return;
         }
 
-        rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
-        rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
+        rename($filename . '.backup', $filename);
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -52,6 +52,23 @@ final class FallbackVersionsTest extends TestCase
         }
     }
 
+    public function testValidVersionsWithoutComposerLock() : void
+    {
+        $lockData = json_decode(file_get_contents(__DIR__ . '/../../composer.lock'), true);
+
+        $packages = array_merge($lockData['packages'], $lockData['packages-dev']);
+
+        self::assertNotEmpty($packages);
+
+        $this->backupFile(__DIR__ . '/../../composer.lock');
+        foreach ($packages as $package) {
+            self::assertSame(
+                $package['version'] . '@' . $package['source']['reference'],
+                FallbackVersions::getVersion($package['name'])
+            );
+        }
+    }
+
     public function testInvalidVersionsAreRejected() : void
     {
         $this->expectException(OutOfBoundsException::class);

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -23,27 +23,18 @@ final class FallbackVersionsTest extends TestCase
 {
     public function testWillFailWithoutValidComposerLockLocation() : void
     {
+        rename(__DIR__ . '/../../vendor/composer/installed.json', __DIR__ . '/../../vendor/composer/installed.json.backup');
         rename(__DIR__ . '/../../composer.lock', __DIR__ . '/../../composer.lock.backup');
 
-        try {
-            FallbackVersions::getVersion('phpunit/phpunit');
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessageRegExp(
+            '@PackageVersions could not locate the `vendor/composer/installed\.json` or your `composer\.lock` '
+            . 'location\. This is assumed to be in \[[^]]+?\]\. If you customized your composer vendor directory and ran composer '
+            . 'installation with --no-scripts or if you deployed without the required composer files, then you are on '
+            . 'your own, and we can\'t really help you\. Fix your shit and cut the tooling some slack\.@'
+        );
 
-            self::fail('An exception was supposed to be thrown');
-        } catch (UnexpectedValueException $lockFileNotFound) {
-            $srcDir = realpath(__DIR__ . '/../../src/PackageVersions');
-
-            self::assertSame(
-                'PackageVersions could not locate your `composer.lock` location. '
-                . 'This is assumed to be in '
-                . json_encode([$srcDir . '/../../../../../composer.lock', $srcDir . '/../../composer.lock'])
-                . '. If you customized your composer vendor directory and ran composer installation with --no-scripts, '
-                . 'then you are on your own, and we can\'t really help you. '
-                . 'Fix your shit and cut the tooling some slack.',
-                $lockFileNotFound->getMessage()
-            );
-        } finally {
-            rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
-        }
+        FallbackVersions::getVersion('phpunit/phpunit');
     }
 
     public function testValidVersions() : void
@@ -67,5 +58,16 @@ final class FallbackVersionsTest extends TestCase
         $this->expectException(OutOfBoundsException::class);
 
         FallbackVersions::getVersion(uniqid('', true) . '/' . uniqid('', true));
+    }
+
+    protected function tearDown()
+    {
+        if (file_exists(__DIR__ . '/../../vendor/composer/installed.json.backup')) {
+            rename(__DIR__ . '/../../vendor/composer/installed.json.backup', __DIR__ . '/../../vendor/composer/installed.json');
+        }
+
+        if (file_exists(__DIR__ . '/../../composer.lock.backup')) {
+            rename(__DIR__ . '/../../composer.lock.backup', __DIR__ . '/../../composer.lock');
+        }
     }
 }

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -11,6 +11,7 @@ use UnexpectedValueException;
 use function array_merge;
 use function file_exists;
 use function file_get_contents;
+use function getcwd;
 use function json_decode;
 use function rename;
 use function uniqid;

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -54,12 +54,6 @@ final class FallbackVersionsTest extends TestCase
 
     public function testValidVersionsWithoutComposerLock() : void
     {
-        // This test will always fail if there is nothing in the installed.json
-        // due to this package being installed with `composer install --no-dev`.
-        if (json_decode(file_get_contents(getcwd() . '/vendor/composer/installed.json', true)) === []) {
-            $this->markTestSkipped('Empty installed.json (possible --no-dev)');
-        }
-
         $lockData = json_decode(file_get_contents(__DIR__ . '/../../composer.lock'), true);
 
         $packages = array_merge($lockData['packages'], $lockData['packages-dev'] ?? []);

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -245,7 +245,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }
@@ -348,7 +348,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }
@@ -455,7 +455,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }
@@ -854,7 +854,7 @@ final class Versions
         }
 
         throw new \OutOfBoundsException(
-            'Required package "' . $packageName . '" is not installed: cannot detect its version'
+            'Required package "' . $packageName . '" is not installed: check your ./vendor/composer/installed.json and/or ./composer.lock files'
         );
     }
 }


### PR DESCRIPTION
Due to #110, we discovered that in some cases, other Composer hooks could interfere with this package, triggering it before it's ready at first install.

#82 solves this issue already, but it's available in 1.5.0, which requires PHP 7.3. Since this package is used by `sentry/sentry` (which requires PHP 7.1), I'm backporting #82 to make this fix available to all Sentry users.