### PR TITLE
Hotfix/fix incorrect composer path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
   - DEPENDENCIES="--no-scripts"
 
 before_script:
+  # aliasing current branch as `master`, since otherwise composer cannot determine the current branch-alias
+  - git branch -D master || true
+  - git checkout -b master
   - composer self-update
   - composer update --prefer-dist $DEPENDENCIES
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "extra": {
         "class": "PackageVersions\\Installer",
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "extra": {
         "class": "PackageVersions\\Installer",
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "1.5.x-dev"
         }
     },
     "scripts": {

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -68,7 +68,7 @@ final class FallbackVersions
             // This package's composer.lock
             __DIR__ . '/../../composer.lock',
         ];
-        
+
         $packageData = [];
         foreach ($checkedPaths as $path) {
             if (! file_exists($path)) {

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -61,12 +61,14 @@ final class FallbackVersions
         $checkedPaths = [
             // The top-level project's ./vendor/composer/installed.json
             getcwd() . '/vendor/composer/installed.json',
+            __DIR__ . '/../../../../composer/installed.json',
             // The top-level project's ./composer.lock
             getcwd() . '/composer.lock',
+            __DIR__ . '/../../../../../composer.lock',
             // This package's composer.lock
             __DIR__ . '/../../composer.lock',
         ];
-
+        
         $packageData = [];
         foreach ($checkedPaths as $path) {
             if (! file_exists($path)) {

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -309,7 +309,7 @@ PHP
 
         self::assertSame(0, $exitCode);
         self::assertCount(1, $output);
-        self::assertRegExp('/^1\\..*\\@[a-f0-9]*$/', $output[0]);
+        self::assertRegExp('/^\d+\\..*\\@[a-f0-9]*$/', $output[0]);
     }
 
     /**

--- a/test/PackageVersionsTest/E2EInstallerTest.php
+++ b/test/PackageVersionsTest/E2EInstallerTest.php
@@ -12,10 +12,12 @@ use SplFileInfo;
 use ZipArchive;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
+use const PHP_BINARY;
 use function array_filter;
 use function array_map;
 use function array_walk;
 use function chdir;
+use function escapeshellarg;
 use function exec;
 use function file_get_contents;
 use function file_put_contents;
@@ -298,7 +300,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 echo \PackageVersions\Versions::getVersion('ocramius/package-versions');
 PHP
-
         );
     }
 


### PR DESCRIPTION
This fixes the issue that cause Laravel installations with a dependency on `1.4.x` to break that are installed using `composer install --no-scripts` as described in #112 