### PR TITLE
Ensure that, when generated, `PackageVersions\Versions::getVersion()` is `@psalm-pure`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ $LOCKED_DEPENDENCIES = '' ]]; then composer update $DEPENDENCIES; fi
 
 script:
-  - ./vendor/bin/psalm
+  - if [[ $DEPENDENCIES != '--no-scripts' ]]; ./vendor/bin/psalm; fi
   # TODO see https://github.com/vimeo/psalm/issues/1881 https://github.com/Ocramius/PackageVersions/issues/90 :
   # - ! ./vendor/bin/psalm test/static-analysis/unhappy-path/unexpected-package-name.php
   - ./vendor/bin/phpunit --disallow-test-output --coverage-clover=clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ $LOCKED_DEPENDENCIES = '' ]]; then composer update $DEPENDENCIES; fi
 
 script:
-  - if [[ "$DEPENDENCIES" != '--no-scripts' ]]; ./vendor/bin/psalm; fi
+  - if [[ "$DEPENDENCIES" != '--no-scripts' ]]; then ./vendor/bin/psalm; fi
   # TODO see https://github.com/vimeo/psalm/issues/1881 https://github.com/Ocramius/PackageVersions/issues/90 :
   # - ! ./vendor/bin/psalm test/static-analysis/unhappy-path/unexpected-package-name.php
   - ./vendor/bin/phpunit --disallow-test-output --coverage-clover=clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ $LOCKED_DEPENDENCIES = '' ]]; then composer update $DEPENDENCIES; fi
 
 script:
-  - if [[ $DEPENDENCIES != '--no-scripts' ]]; ./vendor/bin/psalm; fi
+  - if [[ "$DEPENDENCIES" != '--no-scripts' ]]; ./vendor/bin/psalm; fi
   # TODO see https://github.com/vimeo/psalm/issues/1881 https://github.com/Ocramius/PackageVersions/issues/90 :
   # - ! ./vendor/bin/psalm test/static-analysis/unhappy-path/unexpected-package-name.php
   - ./vendor/bin/phpunit --disallow-test-output --coverage-clover=clover.xml

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -66,6 +66,7 @@ use OutOfBoundsException;
      * @throws OutOfBoundsException If a version cannot be located.
      *
      * @psalm-param key-of<self::VERSIONS> $packageName
+     * @psalm-pure
      */
     public static function getVersion(string $packageName) : string
     {

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -244,6 +244,7 @@ final class Versions
      * @throws OutOfBoundsException If a version cannot be located.
      *
      * @psalm-param key-of<self::VERSIONS> $packageName
+     * @psalm-pure
      */
     public static function getVersion(string $packageName) : string
     {
@@ -358,6 +359,7 @@ final class Versions
      * @throws OutOfBoundsException If a version cannot be located.
      *
      * @psalm-param key-of<self::VERSIONS> $packageName
+     * @psalm-pure
      */
     public static function getVersion(string $packageName) : string
     {
@@ -476,6 +478,7 @@ final class Versions
      * @throws OutOfBoundsException If a version cannot be located.
      *
      * @psalm-param key-of<self::VERSIONS> $packageName
+     * @psalm-pure
      */
     public static function getVersion(string $packageName) : string
     {
@@ -886,6 +889,7 @@ final class Versions
      * @throws OutOfBoundsException If a version cannot be located.
      *
      * @psalm-param key-of<self::VERSIONS> $packageName
+     * @psalm-pure
      */
     public static function getVersion(string $packageName) : string
     {

--- a/test/static-analysis/happy-path/expected-package-name.php
+++ b/test/static-analysis/happy-path/expected-package-name.php
@@ -4,4 +4,8 @@ declare(strict_types=1);
 
 use PackageVersions\Versions;
 
-return Versions::getVersion('ocramius/package-versions');
+/** @psalm-pure */
+function getVersion() : string
+{
+    return Versions::getVersion('ocramius/package-versions');
+}


### PR DESCRIPTION
Note: the fallback version is **NOT** pure, because it does perform filesystem access.