### PR TITLE
Add support for Composer 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php":                 "^7.4.0",
-        "composer-plugin-api": "^1.1.0"
+        "composer-plugin-api": "^1.1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit":          "^9.0.1",
         "infection/infection":      "^0.15.3",
-        "composer/composer":        "^1.9.3",
+        "composer/composer":        "^1.9.3 || ^2.0@dev",
         "ext-zip":                  "^1.15.0",
         "doctrine/coding-standard": "^7.0.2",
         "vimeo/psalm":              "^3.9.3"

--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -78,7 +78,13 @@ final class FallbackVersions
             $data = json_decode(file_get_contents($path), true);
             switch (basename($path)) {
                 case 'installed.json':
-                    $packageData[] = $data;
+                    // composer 2.x installed.json format
+                    if (isset($data['packages'])) {
+                        $packageData[] = $data['packages'];
+                    } else {
+                        // composer 1.x installed.json format
+                        $packageData[] = $data;
+                    }
                     break;
                 case 'composer.lock':
                     $packageData[] = $data['packages'] + ($data['packages-dev'] ?? []);

--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -87,6 +87,16 @@ PHP;
         // Nothing to do here, as all features are provided through event listeners
     }
 
+    public function deactivate(Composer $composer, IOInterface $io) : void
+    {
+        // Nothing to do here, as all features are provided through event listeners
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io) : void
+    {
+        // Nothing to do here, as all features are provided through event listeners
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/test/PackageVersionsTest/FallbackVersionsTest.php
+++ b/test/PackageVersionsTest/FallbackVersionsTest.php
@@ -73,6 +73,10 @@ final class FallbackVersionsTest extends TestCase
     public function testValidVersionsWithoutInstalledJson() : void
     {
         $packages = json_decode(file_get_contents(__DIR__ . '/../../vendor/composer/installed.json'), true);
+        // normalize composer 2.x installed.json format to the 1.x one
+        if (isset($packages['packages'])) {
+            $packages = $packages['packages'];
+        }
 
         if ($packages === []) {
             // In case of --no-dev flag


### PR DESCRIPTION
As per https://github.com/composer/composer/issues/8726 - it'd be good to get popular plugins updated already to avoid blocking everyone later.

Ideally, you'd tag a new 1.4.3 release here so that people using PHP 7.1 and up get a chance to use Composer 2 in combination with this package.. In this case the old package versions won't be still usable as they'll break dependency resolution, so I hope this is enough reason for an exception. There is a `composer2-1.4` branch on my fork which applies cleanly on top of 1.4.2.

Note that to run update with composer 2 you need to use --ignore-platform-reqs as `dealerdirect/phpcodesniffer-composer-installer` is also not updated yet.