### PR TITLE
Fix unhelpful exception message

### DIFF
--- a/src/PackageVersions/FallbackVersions.php
+++ b/src/PackageVersions/FallbackVersions.php
@@ -102,8 +102,8 @@ final class FallbackVersions
         throw new UnexpectedValueException(sprintf(
             'PackageVersions could not locate the `vendor/composer/installed.json` or your `composer.lock` '
             . 'location. This is assumed to be in %s. If you customized your composer vendor directory and ran composer '
-            . 'installation with --no-scripts or if you deployed without the required composer files, then you are on '
-            . 'your own, and we can\'t really help you. Fix your shit and cut the tooling some slack.',
+            . 'installation with --no-scripts, or if you deployed without the required composer files, PackageVersions '
+            . 'can\'t detect installed versions.',
             json_encode($checkedPaths)
         ));
     }


### PR DESCRIPTION
This PR improves the exception message given to the user if no version information could be read. It tells the user that the library can only work in standard environments without telling them to "fix their shit".