### PR TITLE
#148 retrieve root package version also when package is installed with `--no-scripts`

### DIFF
--- a/src/PackageVersions/Versions.php
+++ b/src/PackageVersions/Versions.php
@@ -39,6 +39,13 @@ final class Versions
      */
     public static function getVersion(string $packageName) : string
     {
+        /** @psalm-suppress DeprecatedConstant */
+        if ($packageName === self::ROOT_PACKAGE_NAME) {
+            $rootPackage = InstalledVersions::getRootPackage();
+
+            return $rootPackage['pretty_version'] . '@' . $rootPackage['reference'];
+        }
+
         return InstalledVersions::getPrettyVersion($packageName)
             . '@' . InstalledVersions::getReference($packageName);
     }

--- a/test/PackageVersionsTest/VersionsTest.php
+++ b/test/PackageVersionsTest/VersionsTest.php
@@ -36,6 +36,13 @@ final class VersionsTest extends TestCase
         }
     }
 
+    /** @group #148 */
+    public function testCanRetrieveRootPackageVersion(): void
+    {
+        /** @psalm-suppress DeprecatedConstant */
+        self::assertMatchesRegularExpression('/^.+\@[0-9a-f]+$/', Versions::getVersion(Versions::ROOT_PACKAGE_NAME));
+    }
+
     public function testInvalidVersionsAreRejected(): void
     {
         $this->expectException(OutOfBoundsException::class);


### PR DESCRIPTION
Fixes #148

The root package version, when running with a stub version of `PackageVersions\Versions`
(which happens when installation was run with `--no-scripts` or equivalent), uses a string
that is not recognized by Composer's `composer-runtime-api` tooling: for that special
case, we compare it to the default version that is stored in the constant, and use
composer's tooling to figure out the actual root package version