### PR TITLE
Implement #153 - added `PackageVersions\Versions::rootPackageName()` as replacement for `PackageVersions\Versions::ROOT_PACKAGE_NAME`

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -50,15 +50,24 @@ use OutOfBoundsException;
 %s
 {
     /**
-     * @deprecated please use {@see \Composer\InstalledVersions::getRootPackage()} instead. The
-     *             equivalent expression for this constant's contents is
-     *             `\Composer\InstalledVersions::getRootPackage()['name']`.
+     * @deprecated please use {@see self::rootPackageName()} instead.
      *             This constant will be removed in version 2.0.0.
      */
     public const ROOT_PACKAGE_NAME = '%s';
 
     private function __construct()
     {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
+     *                                  cause any side effects here.
+     */
+    public static function rootPackageName() : string
+    {
+        return InstalledVersions::getRootPackage()['name'];
     }
 
     /**

--- a/src/PackageVersions/Versions.php
+++ b/src/PackageVersions/Versions.php
@@ -18,15 +18,24 @@ use OutOfBoundsException;
 final class Versions
 {
     /**
-     * @deprecated please use {@see \Composer\InstalledVersions::getRootPackage()} instead. The
-     *             equivalent expression for this constant's contents is
-     *             `\Composer\InstalledVersions::getRootPackage()['name']`.
+     * @deprecated please use {@see self::rootPackageName()} instead.
      *             This constant will be removed in version 2.0.0.
      */
     public const ROOT_PACKAGE_NAME = 'unknown/root-package@UNKNOWN';
 
     private function __construct()
     {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
+     *                                  cause any side effects here.
+     */
+    public static function rootPackageName() : string
+    {
+        return InstalledVersions::getRootPackage()['name'];
     }
 
     /**

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -278,15 +278,24 @@ use OutOfBoundsException;
 final class Versions
 {
     /**
-     * @deprecated please use {@see \Composer\InstalledVersions::getRootPackage()} instead. The
-     *             equivalent expression for this constant's contents is
-     *             `\Composer\InstalledVersions::getRootPackage()['name']`.
+     * @deprecated please use {@see self::rootPackageName()} instead.
      *             This constant will be removed in version 2.0.0.
      */
     public const ROOT_PACKAGE_NAME = 'root/package';
 
     private function __construct()
     {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
+     *                                  cause any side effects here.
+     */
+    public static function rootPackageName() : string
+    {
+        return InstalledVersions::getRootPackage()['name'];
     }
 
     /**
@@ -383,15 +392,24 @@ use OutOfBoundsException;
 final class Versions
 {
     /**
-     * @deprecated please use {@see \Composer\InstalledVersions::getRootPackage()} instead. The
-     *             equivalent expression for this constant's contents is
-     *             `\Composer\InstalledVersions::getRootPackage()['name']`.
+     * @deprecated please use {@see self::rootPackageName()} instead.
      *             This constant will be removed in version 2.0.0.
      */
     public const ROOT_PACKAGE_NAME = 'root/package';
 
     private function __construct()
     {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
+     *                                  cause any side effects here.
+     */
+    public static function rootPackageName() : string
+    {
+        return InstalledVersions::getRootPackage()['name'];
     }
 
     /**
@@ -492,15 +510,24 @@ use OutOfBoundsException;
 final class Versions
 {
     /**
-     * @deprecated please use {@see \Composer\InstalledVersions::getRootPackage()} instead. The
-     *             equivalent expression for this constant's contents is
-     *             `\Composer\InstalledVersions::getRootPackage()['name']`.
+     * @deprecated please use {@see self::rootPackageName()} instead.
      *             This constant will be removed in version 2.0.0.
      */
     public const ROOT_PACKAGE_NAME = 'root/package';
 
     private function __construct()
     {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
+     *                                  cause any side effects here.
+     */
+    public static function rootPackageName() : string
+    {
+        return InstalledVersions::getRootPackage()['name'];
     }
 
     /**
@@ -902,15 +929,24 @@ use OutOfBoundsException;
 final class Versions
 {
     /**
-     * @deprecated please use {@see \Composer\InstalledVersions::getRootPackage()} instead. The
-     *             equivalent expression for this constant's contents is
-     *             `\Composer\InstalledVersions::getRootPackage()['name']`.
+     * @deprecated please use {@see self::rootPackageName()} instead.
      *             This constant will be removed in version 2.0.0.
      */
     public const ROOT_PACKAGE_NAME = 'root/package';
 
     private function __construct()
     {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
+     *                                  cause any side effects here.
+     */
+    public static function rootPackageName() : string
+    {
+        return InstalledVersions::getRootPackage()['name'];
     }
 
     /**

--- a/test/PackageVersionsTest/VersionsTest.php
+++ b/test/PackageVersionsTest/VersionsTest.php
@@ -13,11 +13,7 @@ use function file_get_contents;
 use function json_decode;
 use function uniqid;
 
-/**
- * @uses \PackageVersions\FallbackVersions
- *
- * @covers \PackageVersions\Versions
- */
+/** @covers \PackageVersions\Versions */
 final class VersionsTest extends TestCase
 {
     public function testValidVersions(): void
@@ -41,6 +37,12 @@ final class VersionsTest extends TestCase
     {
         /** @psalm-suppress DeprecatedConstant */
         self::assertMatchesRegularExpression('/^.+\@[0-9a-f]+$/', Versions::getVersion(Versions::ROOT_PACKAGE_NAME));
+    }
+
+    /** @group #153 */
+    public function testCanRetrieveRootPackageName(): void
+    {
+        self::assertMatchesRegularExpression('/^[a-z0-9\\-]+\\/[a-z0-9\\-]+$/', Versions::rootPackageName());
     }
 
     public function testInvalidVersionsAreRejected(): void


### PR DESCRIPTION
Please use `PackageVersions\Versions::rootPackageName()` instead of `PackageVersions\Versions::ROOT_PACKAGE_NAME`,
which is deprecated, and will be removed in version `2.0.0`

Fixes #153 