### PR TITLE
 "replace" composer/package-versions-deprecated v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "phpunit/phpunit":          "^9.2.6",
         "vimeo/psalm":              "^3.12.2"
     },
+    "replace": {
+        "composer/package-versions-deprecated": "^1"
+    },
     "autoload": {
         "psr-4": {
             "PackageVersions\\": "src/PackageVersions"


### PR DESCRIPTION
`composer/package-versions-deprecated` doesn't need a v2.
Instead, when a package requires `composer/package-versions-deprecated` v1,
but `ocramius/package-versions` v2 is also required, it should replace the fork from composer.

Makes sense?

/cc @Seldaek FYI