### PR TITLE
Drop `php:^7.4.7` support - switch to only `php:~8.0.0`

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -17,7 +17,6 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
           - "8.0"
         operating-system:
           - "ubuntu-latest"

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -19,7 +19,6 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
           - "8.0"
         operating-system:
           - "ubuntu-latest"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,7 +22,6 @@ jobs:
           - "classmap-authoritative"
           - "no-scripts"
         php-version:
-          - "7.4"
           - "8.0"
         operating-system:
           - "ubuntu-latest"

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -19,7 +19,6 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "7.4"
           - "8.0"
         operating-system:
           - "ubuntu-latest"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php":                  "^7.4.7 || ~8.0.0",
+        "php":                  "~8.0.0",
         "composer-runtime-api": "^2.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09113067c6a7a569d492e7f2006332a4",
+    "content-hash": "8ed6017662cc1652cdd7db150665ce38",
     "packages": [],
     "packages-dev": [
         {
@@ -5142,7 +5142,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4.7 || ~8.0.0",
+        "php": "~8.0.0",
         "composer-runtime-api": "^2.0.0"
     },
     "platform-dev": {


### PR DESCRIPTION
If you require to run both PHP 7 and PHP 8 in different
environments, lock onto `ocramius/package-versions:2.1.0`,
which supports both.